### PR TITLE
Polyfill URL in getImageDataFromURL for Sketch environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pegjs": "^0.10.0",
     "prop-types": "^15.7.2",
     "seedrandom": "^3.0.5",
+    "whatwg-url": "^7.1.0",
     "yoga-layout-prebuilt": "^1.9.5"
   },
   "peerDependencies": {
@@ -84,13 +85,14 @@
     "@skpm/test-runner": "^0.4.1",
     "@types/airbnb-prop-types": "^2.13.1",
     "@types/invariant": "^2.2.31",
-    "@types/node-fetch": "^2.5.4",
     "@types/jest": "^25.2.1",
     "@types/node": "^13.13.2",
+    "@types/node-fetch": "^2.5.4",
     "@types/pegjs": "^0.10.1",
     "@types/react": "^16.9.34",
     "@types/react-test-renderer": "^16.9.2",
     "@types/seedrandom": "^2.4.28",
+    "@types/whatwg-url": "^8.2.0",
     "gitbook-cli": "^2.3.0",
     "gitbook-plugin-anchorjs": "^2.1.0",
     "gitbook-plugin-codeblock-disable-glossary": "0.0.1",

--- a/src/platformBridges/macos.ts
+++ b/src/platformBridges/macos.ts
@@ -6,7 +6,6 @@ import fetch from 'node-fetch';
 import { readFile as nodeReadFile } from 'fs';
 
 const NodeMacOSBridge: PlatformBridge = {
-  // @ts-ignore
   createStringMeasurer,
   findFontName,
   URL,

--- a/src/platformBridges/macos.ts
+++ b/src/platformBridges/macos.ts
@@ -6,8 +6,10 @@ import fetch from 'node-fetch';
 import { readFile as nodeReadFile } from 'fs';
 
 const NodeMacOSBridge: PlatformBridge = {
+  // @ts-ignore
   createStringMeasurer,
   findFontName,
+  URL,
   fetch: fetch as any, // call signatures are not perfectly identical, but we'll make do
   async readFile(path: string): Promise<Buffer> {
     return new Promise((resolve, reject) => {

--- a/src/platformBridges/sketch/index.ts
+++ b/src/platformBridges/sketch/index.ts
@@ -6,8 +6,7 @@ import { findFontName } from './findFontName';
 import readFile from './readFile';
 
 const SketchBridge: PlatformBridge = {
-  // @ts-ignore
-  name: 'sketch', // @ts-ignore – @types/whatwg-url doesn't match Node.js global.URL
+  // @ts-ignore – @types/whatwg-url doesn't match Node.js global.URL
   URL,
   createStringMeasurer,
   findFontName,

--- a/src/platformBridges/sketch/index.ts
+++ b/src/platformBridges/sketch/index.ts
@@ -1,9 +1,14 @@
+import { URL } from 'whatwg-url';
+
 import { PlatformBridge } from '../../types';
 import { createStringMeasurer } from './createStringMeasurer';
 import { findFontName } from './findFontName';
 import readFile from './readFile';
 
 const SketchBridge: PlatformBridge = {
+  // @ts-ignore
+  name: 'sketch', // @ts-ignore – @types/whatwg-url doesn't match Node.js global.URL
+  URL,
   createStringMeasurer,
   findFontName,
   fetch,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -123,6 +123,7 @@ export type ResizeConstraints = {
 
 export type PlatformBridge = {
   createStringMeasurer(textNodes: TextNode[], maxWidth: number): Size;
+  URL: typeof URL;
   findFontName(style: TextStyle): string;
   fetch(input: RequestInfo, init?: RequestInit): Promise<Response>;
   readFile(path: string): Promise<Buffer>;

--- a/src/utils/getImageDataFromURL.ts
+++ b/src/utils/getImageDataFromURL.ts
@@ -40,7 +40,7 @@ export const getImageDataFromURL = (bridge: PlatformBridge) => async (
   }
 
   try {
-    const parsedUrl = new URL(url);
+    const parsedUrl = new bridge.URL(url);
 
     const buffer = await (parsedUrl.protocol === 'file:'
       ? bridge.readFile(parsedUrl.pathname)

--- a/tsconfig.module.json
+++ b/tsconfig.module.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig",
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2017",
     "outDir": "lib/module",
     "module": "esnext"
   },


### PR DESCRIPTION
Also changes `tsconfig.module.json` `target` to `es2017` to let `@skpm/babel-preset` handle whether async/await needs to be polyfilled or not.